### PR TITLE
Oversample in weights calculation

### DIFF
--- a/dwcal/delay_weighted_cal.py
+++ b/dwcal/delay_weighted_cal.py
@@ -664,6 +664,66 @@ def get_weight_mat_with_exponential_window_fit(
     return weight_mat
 
 
+def get_weight_mat_oversampled_with_exponential_window_fit(
+    Nfreqs,
+    Nbls,
+    uvw_array,
+    channel_width_hz,
+    wedge_slope_factor_inner=0.23,
+    wedge_slope_factor_outer=0.7,
+    wedge_delay_buffer=6.5e-8,
+    wedge_variance_inner=1084.9656666412166,
+    wedge_variance_outer=28.966173241799588,
+    window_min_variance=5.06396954e-01,
+    window_exp_amp=1.19213736e03,
+    window_exp_width=6.93325643e-08,
+    oversample_factor=128.,
+):
+
+    c = 3.0 * 10**8  # Speed of light
+    bl_lengths = np.sqrt(np.sum(uvw_array**2.0, axis=1))
+    delay_array = np.fft.fftfreq(Nfreqs*int(oversample_factor), d=channel_width_hz)
+
+    exp_function = (
+        window_exp_amp * np.exp(-np.abs(delay_array) / window_exp_width / 2)
+        + window_min_variance
+    )
+    exp_function[
+        np.where(exp_function > wedge_variance_outer)[0]
+    ] = wedge_variance_outer
+
+    delay_weighting_inv = np.repeat(exp_function[np.newaxis, :], Nbls, axis=0)
+    for delay_ind, delay_val in enumerate(delay_array):
+        wedge_bls_outer = np.where(
+            wedge_slope_factor_outer * bl_lengths / c + wedge_delay_buffer
+            > np.abs(delay_val)
+        )[0]
+        delay_weighting_inv[wedge_bls_outer, delay_ind] = wedge_variance_outer
+        wedge_bls_inner = np.where(
+            wedge_slope_factor_inner * bl_lengths / c + wedge_delay_buffer
+            > np.abs(delay_val)
+        )[0]
+        delay_weighting_inv[wedge_bls_inner, delay_ind] = wedge_variance_inner
+
+    delay_weighting = 1.0 / delay_weighting_inv
+    freq_weighting = np.fft.ifft(delay_weighting, axis=1)
+    freq_weighting = freq_weighting[:, :Nfreqs]
+    weight_mat = np.zeros((Nbls, Nfreqs, Nfreqs), dtype=complex)
+    for freq_ind1 in range(Nfreqs):
+        for freq_ind2 in range(Nfreqs):
+            weight_mat[:, freq_ind1, freq_ind2] = freq_weighting[
+                :, np.abs(freq_ind1 - freq_ind2)
+            ]
+
+    # Make normalization match identity matrix weight mat
+    normalization_factor = (
+        Nfreqs * Nbls / np.sum(np.trace(weight_mat, axis1=1, axis2=2))
+    )
+    weight_mat *= normalization_factor
+
+    return weight_mat
+
+
 def apply_calibration(
     cal,
     data_path="/Users/ruby/Astro/FHD_outputs/fhd_rlb_model_GLEAM_Aug2021",
@@ -986,6 +1046,17 @@ def calibration_optimization(
             metadata_reference.uvw_array,
             metadata_reference.channel_width,
         )
+    elif weight_mat_option == "exponential window fit oversampled":
+        print(
+            "weight_mat_option = 'exponential window fit': Generating wedge excluding weighting matrix with an exponential window fit and oversampling"
+        )
+        sys.stdout.flush()
+        weight_mat = get_weight_mat_oversampled_with_exponential_window_fit(
+            Nfreqs,
+            Nbls,
+            metadata_reference.uvw_array,
+            metadata_reference.channel_width,
+        )
     else:
         print("ERROR: Unknown value of weight_mat_option. Exiting.")
         sys.exit(1)
@@ -1122,10 +1193,11 @@ def calibrate(
         "wedge",
         "gaussian window fit",
         "exponential window fit",
+        "exponential window fit oversampled",
     ]:
         print("ERROR: Unknown value of weight_mat_option.")
         print(
-            'Options are: "diagonal", "wedge", "gaussian window fit", "exponential window fit". Exiting.'
+            'Options are: "diagonal", "wedge", "gaussian window fit", "exponential window fit", "exponential window fit oversampled". Exiting.'
         )
         sys.exit(1)
 

--- a/dwcal/delay_weighted_cal.py
+++ b/dwcal/delay_weighted_cal.py
@@ -560,6 +560,7 @@ def get_weight_mat_with_wedge(
 
     return weight_mat
 
+
 def get_weight_mat_with_exponential_window_fit(
     Nfreqs,
     Nbls,
@@ -573,12 +574,12 @@ def get_weight_mat_with_exponential_window_fit(
     window_min_variance=5.06396954e-01,
     window_exp_amp=1.19213736e03,
     window_exp_width=6.93325643e-08,
-    oversample_factor=128.,
+    oversample_factor=128.0,
 ):
 
     c = 3.0 * 10**8  # Speed of light
     bl_lengths = np.sqrt(np.sum(uvw_array**2.0, axis=1))
-    delay_array = np.fft.fftfreq(Nfreqs*int(oversample_factor), d=channel_width_hz)
+    delay_array = np.fft.fftfreq(Nfreqs * int(oversample_factor), d=channel_width_hz)
 
     exp_function = (
         window_exp_amp * np.exp(-np.abs(delay_array) / window_exp_width / 2)
@@ -618,6 +619,7 @@ def get_weight_mat_with_exponential_window_fit(
     weight_mat *= normalization_factor
 
     return weight_mat
+
 
 def apply_calibration(
     cal,
@@ -1070,9 +1072,7 @@ def calibrate(
         "exponential window fit",
     ]:
         print("ERROR: Unknown value of weight_mat_option.")
-        print(
-            'Options are: "diagonal", "wedge", "exponential window fit". Exiting.'
-        )
+        print('Options are: "diagonal", "wedge", "exponential window fit". Exiting.')
         sys.exit(1)
 
     if log_file_path is not None:

--- a/dwcal/dwcal_tests.py
+++ b/dwcal/dwcal_tests.py
@@ -187,9 +187,7 @@ def test_hess(
         pass_text = "passed"
     else:
         pass_text = "FAILED!!!!!!!!!"
-    print(
-        f"Hess calc., {part1_text}, ant {test_ant}, freq {test_freq}: {pass_text}"
-    )
+    print(f"Hess calc., {part1_text}, ant {test_ant}, freq {test_freq}: {pass_text}")
 
     return np.min(pass_condition)
 
@@ -197,7 +195,7 @@ def test_hess(
 def test_derivative_calculations_all_baselines():
 
     Nants = 10
-    Nbls = int((Nants ** 2 - Nants) / 2)
+    Nbls = int((Nants**2 - Nants) / 2)
     Ntimes = 1
     Nfreqs = 5
 


### PR DESCRIPTION
The frequency weighting should be calculated from an oversampled delay axis.

This PR adds oversampling to a tunable factor in calculation of the weights. It also removes some deprecated weighting functions.